### PR TITLE
[#28] consoleDomain.name in ActiveMQArtemisSecurity is not

### DIFF
--- a/script/cfg/security_config_test.py
+++ b/script/cfg/security_config_test.py
@@ -190,6 +190,12 @@ class TestSecurityConfiguration(unittest.TestCase):
         self.assertTrue(wanted1 in contents)
         self.assertTrue(wanted2 in contents)
 
+    def test_hawtio_domain_update_in_artemis_profile(self):
+        self.context.parse_config_cr("./test-hawtio-console-domain-cr.yaml")
+        self.context.apply()
+        the_checker = checker.SecurityConfigurationChecker(self.context)
+        self.assertTrue(the_checker.artemis_profile_has_key("-Dhawtio.realm=console2"))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/script/cfg/security_configuration_checker.py
+++ b/script/cfg/security_configuration_checker.py
@@ -546,3 +546,11 @@ class SecurityConfigurationChecker:
                     return False
                 i += 1
         return True
+
+    def artemis_profile_has_key(self, expected_key):
+        artemis_profile_file = self.context.get_artemis_profile_file()
+        with open(artemis_profile_file, "rt") as profile:
+            for each_line in profile:
+                if each_line.find(expected_key) >= 0:
+                    return True
+        return False

--- a/script/cfg/test-hawtio-console-domain-cr.yaml
+++ b/script/cfg/test-hawtio-console-domain-cr.yaml
@@ -1,0 +1,76 @@
+typemeta:
+  kind: ActiveMQArtemisSecurity
+  apiversion: broker.amq.io/v1beta1
+objectmeta:
+  name:
+  generatename:
+  namespace:
+  selflink:
+  uid:
+  resourceversion:
+  generation: 0
+  creationtimestamp: 0001-01-01T00:00:00Z
+  deletiontimestamp: null
+  deletiongraceperiodseconds: null
+  labels: {}
+  annotations: {}
+  ownerreferences: []
+  finalizers: []
+  clustername:
+  managedfields: []
+spec:
+  loginmodules:
+    propertiesloginmodules:
+    - name: module1
+      users:
+      - name: user1
+        password: password1
+        roles:
+        - role1
+        - role2
+      - name: user2
+        password: password2
+        roles:
+        - role3
+        - role1
+    guestloginmodules: []
+    keycloakloginmodules: []
+  securitydomains:
+    brokerdomain:
+      name: activemq
+      loginmodules:
+      - name: module1
+        flag: required
+        debug: true
+        reload: true
+    consoledomain:
+      name: console2
+      loginmodules:
+      - name: module1
+        flag: required
+        debug: null
+        reload: null
+  securitysettings:
+    broker: []
+    management:
+      hawtioroles: []
+      connector:
+        host: null
+        port: null
+        rmiregistryport: null
+        jmxrealm: null
+        objectname: null
+        authenticatortype: null
+        secured: null
+        keystoreprovider: null
+        keystorepath: null
+        keystorepassword: null
+        truststoreprovider: null
+        truststorepath: null
+        truststorepassword: null
+        passwordcodec: null
+      authorisation:
+        allowedlist: []
+        defaultaccess: []
+        roleaccess: []
+  applytocrnames: []


### PR DESCRIPTION
reflected in artemis.profile (-Dhawtio.realm is not changed)