### PR TITLE
[#52] Set non root user 185

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ RUN microdnf install -y python38 python38-jinja2 python38-pyyaml && \
 
 RUN python3 setup.py install
 
+USER 185
+
 LABEL name="artemiscloud/activemq-artemis-broker-init"
 LABEL description="ActiveMQ Artemis broker init container image"
 LABEL maintainer="Howard Gao <hgao@redhat.com>"


### PR DESCRIPTION
The user root cause errors in containers with securityContext.runAsNonRoot = true