### PR TITLE
[#69] Set GID 0 for Kubernetes volumes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN microdnf install -y python3 python3-jinja2 python3-pyyaml && \
 
 RUN python3 setup.py install
 
-USER 185
+# The user is in the group 0 to have access to the volumes mounted
+# by Kubernetes that are typically owned by UID 0 (root) and GID 0 (root).
+USER 185:0
 
 LABEL name="arkmq-org/arkmq-org-broker-init"
 LABEL description="ArkMQ Broker Init is a container image for configuring Apache Artemis broker instances in containerized environments"


### PR DESCRIPTION
Setting GID 0 (root group) allows containers running on Kubernetes to access files in mounted volumes that are typically owned by UID 0 (root) and GID 0 (root)